### PR TITLE
Add a script to package, compile, and collect jar files for SF110

### DIFF
--- a/compileSF110.sh
+++ b/compileSF110.sh
@@ -1,0 +1,24 @@
+#get SF110 benchmark sources
+wget http://www.evosuite.org/files/SF110-20130704-src.zip
+unzip SF110-20130704-src.zip
+rm SF110-20130704-src.zip
+
+find SF110-20130704-src -maxdepth 1 -type d -print0 |
+
+#loop over all benchmark projects
+while IFS= read -rd '' dir; 
+do 
+
+#build src and test jars
+ant jar -f $dir;
+ant jar-tests -f $dir;
+
+echo $dir;
+folder="$(basename $dir)";
+echo $folder
+
+#find generated jars and move them to bins/ folder
+find $dir -name '*.jar' -maxdepth 1 -exec sh -c 'mkdir -p bins/'$folder' && cp {} bins/'$folder'' _ {}  \;
+
+done
+


### PR DESCRIPTION
To execute, just run `./compileSF110.sh`. It will generate `jar` and `tests.jar` in bins for every single project of SF project.